### PR TITLE
Changed submodule URL to public URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/spreadsheet-reader"]
 	path = lib/spreadsheet-reader
-	url = git@github.com:ho-nl/spreadsheet-reader.git
+	url = https://github.com/ho-nl/spreadsheet-reader.git


### PR DESCRIPTION
Fix for the error

Permission denied (publickey).
fatal: The remote end hung up unexpectedly

when installing the module via modman. The SSH URL didn't work as I don't have contributor permissions for the submodule repository.
