### PR TITLE
Fixed error for backend menu "H&O Import"

### DIFF
--- a/app/code/local/Ho/Import/Model/Resource/System/Import/Collection.php
+++ b/app/code/local/Ho/Import/Model/Resource/System/Import/Collection.php
@@ -77,6 +77,9 @@ class Ho_Import_Model_Resource_System_Import_Collection extends Varien_Data_Coll
 
     public function getData() {
         $profileNodes =  Mage::getConfig()->getNode('global/ho_import');
+        if ($profileNodes === false) {
+            return array();
+        }
         return $profileNodes->asArray();
     }
 


### PR DESCRIPTION
If no import is defined in the XML and you call the backend page "System > Import/Export > H&O Import", you get an error:

Fatal error: Call to a member function asArray() on a non-object in /path/to/magento/app/code/local/Ho/Import/Model/Resource/System/Import/Collection.php on line 80

This fix checks whether a node is returned.
