### PR TITLE
Rethrow exception instead of exiting script.

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -698,8 +698,8 @@ class Ho_Import_Model_Import extends Varien_Object
                 'Exception while running profile %s, ran for %s seconds',
                 $this->getProfile(), $seconds
             ), Zend_Log::CRIT);
-            Mage::printException($e);
-            exit;
+            Mage::logException($e);
+            throw $e;
         }
 
         $seconds           = round(microtime(TRUE) - $timer, 2);


### PR DESCRIPTION
When something bad happens during the import, it should be possible to catch the error and continue running our own exception handling.

For example, we usually run your importer model from our own module, and if something bad happens, we want to be able to catch it, so we can send an e-mail or something when this happens.

This wasn't possible because the `Mage::printException` method calls `die()`.
I changed this to `logException` and replaced your `exit` call with a rethrow.

This way we can catch the exception and continue with our script and send an e-mail (or do something else) when this happens.


If you have a reason to not accept this pull request, maybe we can turn it into a config option, so people can choose what happens?