### PR TITLE
Removed type hint from constructor; strings are also allowed

### DIFF
--- a/app/code/community/Ho/Import/Model/Source/Adapter/Spreadsheet.php
+++ b/app/code/community/Ho/Import/Model/Source/Adapter/Spreadsheet.php
@@ -34,7 +34,7 @@ class Ho_Import_Model_Source_Adapter_Spreadsheet extends SpreadsheetReader
      */
     protected $_colNames = array();
 
-    public function __construct(array $config)
+    public function __construct($config)
     {
         $source = is_string($config) ? $config : $config['file'];
         if (!is_string($source)) {


### PR DESCRIPTION
See #61. It caused an error when there's only one argument to pass to the source adapter.