### PR TITLE
Allow data to persist on transport object when importing csv

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -406,7 +406,11 @@ class Ho_Import_Model_Import extends Varien_Object
             }
             foreach ($transport->getItems() as $preparedItem) {
                 $result = $this->_fieldMapItem($preparedItem);
+                // get any data added to the transport object
+                $transportData = $transport->getData();
                 $transport = $this->_getTransport()->setItems($result);
+                // set data back to transport object
+                $transport->setData($transportData);
                 $this->_runEvent('source_row_fieldmap_after', $transport);
                 foreach ($transport->getItems() as $row) {
                     $rowCount++;


### PR DESCRIPTION
This small change allows one to add data (perhaps an array containing simple products) to the transport object and use this data during the events. 
An example would be. One create an array of simple product in a method called when the source_row_fieldmap_before event is dispatched. One then pick those items up at the source_row_fieldmap_after event where one can do
```php
public function sourceRowFieldmapAfter($transport)
    {
        $simpleProducts = $transport->getData('simple_products');
        $transport->setItems(array_merge($transport->getItems(), $simpleProducts));
    }
```  
