### PR TITLE
Added is_numeric check

### DIFF
--- a/app/code/community/Ho/Import/Model/Mapper.php
+++ b/app/code/community/Ho/Import/Model/Mapper.php
@@ -152,7 +152,9 @@ class Ho_Import_Model_Mapper
         //iffieldvalue
         if (isset($attributes['iffieldvalue'])) {
             $field = $attributes['iffieldvalue'];
-            if (! isset($item[$field]) || empty($item[$field])) {
+            // erisler - fix: value could be "0" which is valid magento value but empty(0) is true
+//            if (! isset($item[$field]) || empty($item[$field])) {
+            if (! isset($item[$field]) || (empty($item[$field]) && !is_numeric($item[$field]))) {
                 return isset($attributes['ignoreifempty']) ? $this->_symbolIgnoreFields : null;
             }
         }
@@ -160,7 +162,9 @@ class Ho_Import_Model_Mapper
         //unlessfieldvalue
         if (isset($attributes['unlessfieldvalue'])) {
             $field = $attributes['unlessfieldvalue'];
-            if (isset($item[$field]) && !empty($item[$field])) {
+            // erisler - fix: value could be "0" which is valid magento value but empty(0) is true
+//            if (isset($item[$field]) && !empty($item[$field])) {
+            if (isset($item[$field]) && (!empty($item[$field]) || is_numeric($item[$field]))) {
                 return isset($attributes['ignoreifempty']) ? $this->_symbolIgnoreFields : null;
             }
         }
@@ -235,12 +239,16 @@ class Ho_Import_Model_Mapper
         }
 
         // defaultvalue
-        if (isset($attributes['defaultvalue']) && empty($result)) {
+        // erisler - fix: value could be "0" which is valid magento value but empty(0) is true
+//        if (isset($attributes['defaultvalue']) && empty($result)) {
+        if (isset($attributes['defaultvalue']) && (empty($result) && !is_numeric($result))) {
             $result = $attributes['defaultvalue'];
         }
 
         //ignoreifempty
-        if (isset($attributes['ignoreifempty']) && empty($result)) {
+        // erisler - fix: value could be "0" which is valid magento value but empty(0) is true
+        if (isset($attributes['ignoreifempty']) && (empty($result) && !is_numeric($result))) {
+//        if (isset($attributes['ignoreifempty']) && empty($result)) {
             $result = $this->_symbolIgnoreFields;
         }
 


### PR DESCRIPTION
When checking the value for
iffieldvalue/unlessfieldvalue/defaultvalue/ignoreifempty conditions,
without is_numeric, the value of ‘0’ (zero) would result in
empty()===true. However, ‘0’ is a valid value for a lot of attributes
hence we want to exclude that for the empty test.