### PR TITLE
Bugfix related to archive_import_files and feature added to <fieldmap>

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -963,7 +963,7 @@ class Ho_Import_Model_Import extends Varien_Object
      */
     protected function _archiveOldCsv()
     {
-        $allowArchive = (bool) $this->_getConfigNode(self::IMPORT_CONFIG_IMPORT_OPTIONS.'/archive_import_files');
+        $allowArchive = (bool) ((string)$this->_getConfigNode(self::IMPORT_CONFIG_IMPORT_OPTIONS.'/archive_import_files'));
 
         $fileName = $this->_getFileName();
         if (!$allowArchive || !file_exists($fileName)) {

--- a/app/code/community/Ho/Import/Model/Mapper.php
+++ b/app/code/community/Ho/Import/Model/Mapper.php
@@ -295,11 +295,18 @@ class Ho_Import_Model_Mapper
 
             if ($usePath = $fieldMapNode->getAttribute('use')) {
                 $fieldMapPath = sprintf(self::IMPORT_FIELD_CONFIG_PATH, $usePath);
-                $fieldMapNode = Mage::getConfig()->getNode($fieldMapPath);
+                $useFieldMapNode = Mage::getConfig()->getNode($fieldMapPath);
 
-                if (! $fieldMapNode) {
+                if (! $useFieldMapNode) {
                     Mage::throwException(sprintf("Incorrect 'use' in <fieldmap use=\"%s\" />", $usePath));
                 }
+            }
+            
+            // If the user has specified a "use" attribute then we will merge the two XML trees
+            // Only merge if both tress have children.
+            if ($useFieldMapNode && $useFieldMapNode->count()>0 && $fieldMapNode->count()>0) {
+                $useFieldMapNode->extend($fieldMapNode, true);
+                $fieldMapNode = $useFieldMapNode;
             }
 
             $columns = $fieldMapNode->children();


### PR DESCRIPTION
	1. Bugfix: <archive_import_files> always 1 …
SimpleXMLElements do not cast to (bool) as expected…since it will
always be an object the bool will always be true. Instead, cast to
string first to execute the __toString() and then cast that value to
bool.

    2. Feature: allow updates when using <fieldmap use=""> …
This will merge any local <fieldmap> definitions with the definitions
defined in the “use” profile. You can overwrite and add new field
definitions as follows:

```
<fieldmap use=“other_map”>
   <!— change the sky to use a different column name —>
   <sku field=“new_sku_col” />
   <!— add a custom field —>
   <some_attribute field=“col_name” />
</field_map>
```