### PR TITLE
Invalid entity catalog_category_product and small XML file fixes

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -1150,6 +1150,14 @@ class Ho_Import_Model_Import extends Varien_Object
      */
     protected function _cleanEntityLinkTable()
     {
+        /**
+         * Skip this procedure if entity type is catalog_category_product.
+         * Magento does not recognise such type(\Ho_Import_Model_Import::_getEntityTypeId() fails) neither needed in this method at all.
+         */
+        if ($this->_getEntityType() == self::IMPORT_TYPE_CATEGORY_PRODUCT) {
+            return;
+        }
+
         $resource = Mage::getSingleton('core/resource');
 
         /** @var Magento_Db_Adapter_Pdo_Mysql $adapter */

--- a/app/code/community/Ho/Import/Model/Source/Adapter/Xml.php
+++ b/app/code/community/Ho/Import/Model/Source/Adapter/Xml.php
@@ -85,6 +85,8 @@ class Ho_Import_Model_Source_Adapter_Xml implements SeekableIterator
      */
     private $_chunkSize = 8192;
 
+    private $single_chunk = false;
+
     /**
      * From wehere to start reading
      * @var
@@ -510,6 +512,12 @@ class Ho_Import_Model_Source_Adapter_Xml implements SeekableIterator
     {
         $this->_chunk .= fread($this->_fileHandler, $this->_chunkSize);
         $this->_readBytes += $this->_chunkSize;
+
+        if ($this->_totalBytes <= $this->_chunkSize && !$this->single_chunk) {
+            $this->single_chunk = true;
+            return true;
+        }
+
         if ($this->_readBytes >= $this->_totalBytes) {
             $this->_readBytes = $this->_totalBytes;
             return false;


### PR DESCRIPTION
1) Fix for error 'Invalid entity_type specified: catalog_category_product' when importing category product relations.
2) Fix for importing small XML files