### PR TITLE
Fix division by zero error when importing happens too fast

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -737,12 +737,12 @@ class Ho_Import_Model_Import extends Varien_Object
             throw $e;
         }
 
-        $seconds           = round(microtime(true) - $timer, 2);
+        $seconds           = microtime(true) - $timer;
         $rowsPerSecond     = round($this->getRowCount() / $seconds, 2);
         $entitiesPerSecond = round($this->getEntityCount() / $seconds, 2);
         $this->_getLog()->log($this->_getLog()->__(
             'Profile %s done in %s seconds, %s entities/s, %s rows/s.',
-            $profile, $seconds, $entitiesPerSecond, $rowsPerSecond
+            $profile, round($seconds, 4), $entitiesPerSecond, $rowsPerSecond
         ));
 
         return $this->_fastSimpleImport->getErrors();


### PR DESCRIPTION
I was writing a very simple import profile and that seemed to happen faster than 0.005 seconds. 

Because the delta gets rounded to 2 decimals, it will result as 0 seconds. When calculating how many rows/entities per seconds, the importer will end up dividing by zero. This way the calculations will be legit again, more precise and the displayed delta will now be rounded to 4 decimals instead of 2. 

If you have a different opinion on this issue, please let me know!