### PR TITLE
Fix issue that wrong fieldmap was used and xml was reloaded on every request

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -53,6 +53,7 @@ class Ho_Import_Model_Import extends Varien_Object
      * @var AvS_FastSimpleImport_Model_Import
      */
     protected $_fastSimpleImport = NULL;
+    protected $_finalConfig = null;
 
     protected function _construct()
     {
@@ -581,7 +582,7 @@ class Ho_Import_Model_Import extends Varien_Object
      *
      * @return array
      */
-    protected function _fieldMapItemExtract($fieldConfig)
+    protected function _fieldMapItemExtract($fieldConfigs)
     {
         $itemRows = array();
 
@@ -589,7 +590,7 @@ class Ho_Import_Model_Import extends Varien_Object
         $symbolForClearField = $this->_fastSimpleImport->getSymbolEmptyFields();
 
         //Step 1: Get the values for the fields
-        foreach ($fieldConfig as $storeCode => $fields) {
+        foreach ($fieldConfigs as $storeCode => $fields) {
             $mapper->setStoreCode($storeCode);
             /** @var $column Mage_Core_Model_Config_Element */
             foreach ($fields as $fieldName => $fieldConfig) {

--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -53,7 +53,6 @@ class Ho_Import_Model_Import extends Varien_Object
      * @var AvS_FastSimpleImport_Model_Import
      */
     protected $_fastSimpleImport = NULL;
-    protected $_finalConfig = null;
 
     protected function _construct()
     {

--- a/app/code/community/Ho/Import/Model/Mapper.php
+++ b/app/code/community/Ho/Import/Model/Mapper.php
@@ -300,8 +300,8 @@ class Ho_Import_Model_Mapper
             }
 
             if ($usePath = $fieldMapNode->getAttribute('use')) {
-                $fieldMapPath = sprintf(self::IMPORT_FIELD_CONFIG_PATH, $usePath);
-                $useFieldMapNode = Mage::getConfig()->getNode($fieldMapPath);
+                $fieldMapPathExtend = sprintf(self::IMPORT_FIELD_CONFIG_PATH, $usePath);
+                $useFieldMapNode = Mage::getConfig()->getNode($fieldMapPathExtend);
 
                 if (! $useFieldMapNode) {
                     Mage::throwException(sprintf("Incorrect 'use' in <fieldmap use=\"%s\" />", $usePath));

--- a/app/code/community/Ho/Import/Model/Mapper.php
+++ b/app/code/community/Ho/Import/Model/Mapper.php
@@ -341,6 +341,9 @@ class Ho_Import_Model_Mapper
 
         if (! is_null($fieldName)) {
             if (! isset($this->_fieldConfig[$fieldMapPath][$this->getStoreCode()][$fieldName])) {
+                if (isset($this->_fieldConfig[$fieldMapPath]['admin'][$fieldName])) {
+                    return $this->_fieldConfig[$fieldMapPath]['admin'][$fieldName];
+                }
                 return null;
             }
             return $this->_fieldConfig[$fieldMapPath][$this->getStoreCode()][$fieldName];


### PR DESCRIPTION
The field configs was reloaded every time when a `<fielmap use="other_profile">` is used.
In 5.6+ this is no issue, in 5.5 somehow the arguments are in the wrong order when reloaded for a second time.